### PR TITLE
Update example in README to use python builtin module isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ pip install bluefin_v2_client
 Alternatively, you could run:
 
 ```
+python -m venv .venv
+source .venv/bin/activate
 pip install .
 ```
 


### PR DESCRIPTION
Update example in README to use python builtin module isolation i.e. venv when building python library directly from code