### PR TITLE
Resolve conflicting dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
   'python-socketio ~= 5.8.0',
   'six ~= 1.16.0',
   'socketio ~= 0.2.1',
-  'websocket ~= 0.2.1',
   'websocket-client ~= 1.6.2',
   'yarl ~= 1.9.2',
   'zope.event ~= 5.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
   'python-engineio ~= 4.6.0',
   'python-socketio ~= 5.8.0',
   'six ~= 1.16.0',
-  'socketio ~= 0.2.1',
   'websocket-client ~= 1.6.2',
   'yarl ~= 1.9.2',
   'zope.event ~= 5.0',

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,6 @@ python-engineio==4.6.0
 python-socketio==5.8.0
 six==1.16.0
 socketio==0.2.1
-websocket==0.2.1
 websocket-client==1.6.2
 yarl==1.9.2
 zope.event==5.0

--- a/requirements.in
+++ b/requirements.in
@@ -23,8 +23,7 @@ pycryptodome==3.18.0
 PyNaCl==1.5.0
 python-engineio==4.6.0
 python-socketio==5.8.0
-six==1.16.0
-socketio==0.2.1
+six==1.16.0s
 websocket-client==1.6.2
 yarl==1.9.2
 zope.event==5.0


### PR DESCRIPTION
By specifying both `websocket` and `websocket-client` as dependencies, your packages can end in an indeterminant state as both provide the `websocket` library.  The leads to a situation where you need to run `pip uninstall websocket-client` and `pip install websocket-client` to get this package to load. As this overwrites the base `websocket` package, removing this from the requirements resolves the issue.

A similar conflict between `socketio` and `python-socketio` exists, which breaks installation with `poetry`.