### PR TITLE
[BLB-370] init method update to provide token to avoid onboarding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluefin_v2_client_sui"
-version = "1.1.4"
+version = "1.1.5"
 description = "Library to interact with Bluefin exchange protocol including its off-chain api-gateway and on-chain contracts"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
# Description

- Updated init method to take auth_token as input to skip onboarding

# Checklist:
- [ ] All changes in this PR are at least one version backwards compatible, (reverting this PR is safe eg data migrations are backwards compatible).
- [ ] I have performed a thorough self-review of my code
- [ ] I have commented the code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md, architecture docs, public docs, etc).
