### PR TITLE
fix decimal_to_bcs func

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bluefin_v2_client_sui"
-version = "1.1.11"
+version = "1.1.12"
 description = "Library to interact with Bluefin exchange protocol including its off-chain api-gateway and on-chain contracts"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/sui_utils/utilities.py
+++ b/src/sui_utils/utilities.py
@@ -180,7 +180,7 @@ def config_logging(logging, logging_level, log_file: str = None):
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
-def decimal_to_bcs(self, num):
+def decimal_to_bcs(num):
         # Initialize an empty list to store the BCS bytes
         bcs_bytes = []
         while num > 0:


### PR DESCRIPTION
### **User description**
# Description

- removed self from `decimal_to_bcs` func as it's not a class method

# Checklist:
- [ ] All changes in this PR are at least one version backwards compatible, (reverting this PR is safe eg data migrations are backwards compatible).
- [ ] I have performed a thorough self-review of my code
- [ ] I have commented the code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md, architecture docs, public docs, etc).


___

### **PR Type**
Bug fix


___

### **Description**
- Removed `self` parameter from `decimal_to_bcs` function.

- Updated `decimal_to_bcs` to be a standalone function.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utilities.py</strong><dd><code>Refactor `decimal_to_bcs` to standalone function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/sui_utils/utilities.py

<li>Removed <code>self</code> parameter from <code>decimal_to_bcs</code> function.<br> <li> Made <code>decimal_to_bcs</code> a standalone function.


</details>


  </td>
  <td><a href="https://github.com/fireflyprotocol/bluefin-v2-client-python/pull/83/files#diff-060d16f4555c3f99cf2ecb356b4ce0ded8cc0470f80c2b0edcc6ad6cd7c073c2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>